### PR TITLE
fix(ts): Plan/MCQQuestion 타입 변경 후 누락된 갱신 반영 (#2)

### DIFF
--- a/src/__tests__/sessionStore.test.ts
+++ b/src/__tests__/sessionStore.test.ts
@@ -15,7 +15,7 @@ function makeContent(sessionId: string): StudyContent {
         id: 'q1', question: 'What is AI?',
         options: { A: 'Artificial Intelligence', B: 'Auto Index', C: 'Algorithm', D: 'None' },
         correct_answer: 'A', explanation: 'AI stands for Artificial Intelligence.',
-        concept_id: 'c1', difficulty: 'easy',
+        concept_id: 'c1', level: 1, question_type: 'concept',
       },
     ],
     fill_questions: [],

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -3,7 +3,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ActivityIndicator, View } from 'react-native';
 import * as Linking from 'expo-linking';
-import { hasPlanSelected, getPlan, hasApiKey } from '../services/api';
+import { hasPlanSelected, hasApiKey } from '../services/api';
 import { useLanguageStore } from '../store/languageStore';
 import { useAuthStore } from '../store/authStore';
 import { supabase } from '../services/supabase';
@@ -80,9 +80,8 @@ export default function AppNavigator() {
         setInitialRoute('PlanSelection');
         return;
       }
-      const plan = await getPlan();
-      // 유료 플랜인데 API 키가 없으면 다시 설정 화면으로
-      if (plan !== 'free' && !(await hasApiKey())) {
+      // 모든 플랜이 API 키를 요구 — 키가 없으면 설정 화면으로
+      if (!(await hasApiKey())) {
         setInitialRoute('PlanSelection');
         return;
       }

--- a/src/screens/UploadScreen.tsx
+++ b/src/screens/UploadScreen.tsx
@@ -105,8 +105,8 @@ export default function UploadScreen({ navigation }: Props) {
 
   async function doUpload(subjectId: string | null) {
     const plan = (await getPlan()) ?? 'paid';
-    const apiKey = plan !== 'free' ? (await getApiKey() ?? '') : '';
-    if (plan !== 'free' && !apiKey) {
+    const apiKey = (await getApiKey()) ?? '';
+    if (!apiKey) {
       Alert.alert(s.uploadNoApiKey, s.uploadNoApiKeyDesc);
       return;
     }

--- a/src/screens/WrongAnswerScreen.tsx
+++ b/src/screens/WrongAnswerScreen.tsx
@@ -103,7 +103,8 @@ export default function WrongAnswerScreen({ route, navigation }: Props) {
     setSaving(false);
 
     if (retryIds.length > 0) {
-      navigation.replace('MCQ', { sessionId, retryIds });
+      // retryIds 가 mode 필터보다 우선하므로 mode 는 placeholder
+      navigation.replace('MCQ', { sessionId, mode: 'exam', retryIds });
     } else {
       navigation.navigate('Home');
     }

--- a/src/store/modelStore.ts
+++ b/src/store/modelStore.ts
@@ -37,14 +37,12 @@ export const PLAN_MODELS: Record<Plan, string[]> = {
     // Qwen
     'qwen-qwq-32b',
   ],
-  free: ['gemini-2.0-flash', 'gemini-1.5-flash', 'gemini-1.5-pro'],
 };
 
 export const DEFAULT_MODELS: Record<Plan, string> = {
   paid:   'claude-sonnet-4-6',
   gpt:    'gpt-4o-mini',
   timely: 'auto',
-  free:   'gemini-2.0-flash',
 };
 
 interface ModelStore {


### PR DESCRIPTION
Closes #2

## Summary
- `Plan` 에서 `'free'` 가 빠지고 `MCQQuestion` 의 `difficulty` 가 `level + question_type` 으로 바뀐 변경에 누락된 파일들을 동기화
- `npx tsc --noEmit` 의 TS2353 / TS2367 / TS2345 7건 해소

## Changes
- `src/__tests__/sessionStore.test.ts` — fixture 의 `difficulty` → `level + question_type`
- `src/store/modelStore.ts` — `PLAN_MODELS` / `DEFAULT_MODELS` 의 `free` 항목 제거
- `src/navigation/AppNavigator.tsx` — `plan !== 'free'` 데드 분기 정리, 사용 안 되는 `getPlan` import 제거
- `src/screens/UploadScreen.tsx` — 동일 데드 분기 정리
- `src/screens/WrongAnswerScreen.tsx` — `MCQ` 재시도 네비게이션에 `mode: 'exam'` placeholder 전달 (`retryIds` 가 mode 필터를 우선)

## Test plan
- [x] `npx tsc --noEmit` 로컬 통과 (exit 0)
- [ ] GitHub Actions `Run npx tsc --noEmit` 단계 통과 확인
- [ ] 기존 sessionStore 단위 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)