### PR TITLE
feat(ci): EAS Update/Build 자동화 + expo-doctor 헬스체크 (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
 
+      - name: Expo doctor (config / dependency 헬스체크)
+        run: npx expo-doctor
+
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,62 @@ jobs:
         with:
           fail_ci_if_error: false
 
-  # EAS Update / Build는 CI에서 제외 — 로컬에서 수동 실행
-  # eas update --branch main --non-interactive
-  # eas build --platform android --profile preview --non-interactive
-  # eas build --platform ios --profile preview --non-interactive
+  # ──────────────────────────────────────
+  # 2. EAS Update — develop push 시 OTA 배포 (preview 채널)
+  # ──────────────────────────────────────
+  eas-update:
+    name: EAS Update (preview)
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Set up EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish update to preview channel
+        run: eas update --branch preview --message "${{ github.event.head_commit.message }}" --non-interactive
+
+  # ──────────────────────────────────────
+  # 3. EAS Build — main push 시 production 빌드 (네이티브)
+  # ──────────────────────────────────────
+  eas-build:
+    name: EAS Build (production)
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Set up EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Trigger production build (Android + iOS)
+        run: eas build --profile production --platform all --non-interactive --no-wait

--- a/README.md
+++ b/README.md
@@ -440,26 +440,41 @@ eas build --platform ios --profile production
 
 ### 빌드 프로파일 (`eas.json`)
 
-| 프로파일 | 용도 | 배포 방식 |
-|----------|------|-----------|
-| `development` | 로컬 개발, 시뮬레이터 | 내부 배포 |
-| `preview` | QA 테스트 | 내부 배포 (APK) |
-| `production` | 스토어 배포 | App Bundle |
+| 프로파일 | 용도 | 배포 방식 | EAS Update 채널 | APP_ENVIRONMENT |
+|----------|------|-----------|------------------|------------------|
+| `development` | 로컬 개발, 시뮬레이터 | 내부 배포 | `development` | dev (default) |
+| `preview` | QA 테스트 (develop 브랜치 OTA 대상) | 내부 배포 (APK) | `preview` | `staging` (별도 bundle ID) |
+| `production` | 스토어 배포 | App Bundle | `production` | `production` |
+
+`runtimeVersion` 정책은 `appVersion` (네이티브 호환성 키 = `version` 필드). `app.config.ts`에 `updates.url` (`https://u.expo.dev/<projectId>`) 설정됨.
 
 ---
 
 ## CI/CD
 
-`main` 브랜치에 push 시 자동 실행 (`.github/workflows/ci.yml`):
+`.github/workflows/ci.yml` (모바일 레포) — `main` / `develop` push 및 PR 시 실행:
 
 ```
-1. Test    → lint + 타입체크 + Jest + codecov
-2. Build   → EAS Android 빌드 (preview)
-3. Build   → EAS iOS 빌드 (preview, macOS runner)
+공통 (모든 push/PR):
+  test  → lint + tsc --noEmit + Jest coverage + Codecov 업로드
+
+develop push 시:
+  eas-update  → eas update --branch preview --non-interactive
+                (OTA, 30초~2분 — 네이티브 빌드 없음)
+
+main push 시:
+  eas-build   → eas build --profile production --platform all --non-interactive --no-wait
+                (네이티브 빌드 15~30분, 백그라운드 트리거)
 ```
+
+| 브랜치 | 트리거 | 결과 |
+|--------|--------|------|
+| `develop` push | EAS Update → `preview` 채널 | 이미 설치된 preview 빌드 사용자에게 OTA 반영 |
+| `main` push | EAS Build → `production` 프로파일 | 새 네이티브 바이너리 (스토어 업로드용) |
+| PR | test job만 | 머지 전 검증 |
 
 필요한 GitHub Secrets:
 
 | Secret | 설명 |
 |--------|------|
-| `EXPO_TOKEN` | Expo 계정 토큰 |
+| `EXPO_TOKEN` | Expo 계정 토큰 (`expo.dev` → Account Settings → Access Tokens) |

--- a/app.config.ts
+++ b/app.config.ts
@@ -17,6 +17,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   slug: 'fundamentals',
   scheme: 'studyhelper',
   version: '1.0.0',
+  runtimeVersion: { policy: 'appVersion' },
+  updates: {
+    url: 'https://u.expo.dev/165d5a36-a5e2-4d7b-aef9-4de9374d73aa',
+  },
   orientation: 'portrait',
   icon: './assets/icon.png',
   userInterfaceStyle: 'automatic',

--- a/eas.json
+++ b/eas.json
@@ -6,19 +6,22 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "channel": "development",
       "ios": { "simulator": true }
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "android": { "buildType": "apk" },
       "ios": { "simulator": true },
       "env": {
         "BACKEND_URL": "https://study-helper-backend-production.up.railway.app",
-        "APP_ENVIRONMENT": "production"
+        "APP_ENVIRONMENT": "staging"
       }
     },
     "production": {
       "autoIncrement": true,
+      "channel": "production",
       "android": { "buildType": "app-bundle" }
     }
   },


### PR DESCRIPTION
Closes #4

## Summary
- GitHub Actions 에 EAS Update / Build 자동화 도입
- `develop` → preview 채널, `main` → production 채널 + EAS Build
- `expo-doctor` 헬스체크 단계 추가
- `eas.json` 채널 정의, `app.config.ts` runtimeVersion/updates.url 정리

## Changes
- `.github/workflows/ci.yml` — lint/test + EAS Update/Build + expo-doctor
- `eas.json` — 업데이트 채널 정의
- `app.config.ts` — updates 관련 설정 정리
- `README.md` — CI/CD 흐름·필요 시크릿(`EXPO_TOKEN`) 안내

## Test plan
- [ ] PR 의 `lint` / `test` / `expo-doctor` 단계 통과
- [ ] develop 머지 시 preview 채널로 EAS Update 발행 확인
- [ ] (별도) main 머지 시 production 채널 + EAS Build 트리거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)