### PR TITLE
fix(test): jest 옵션 오타 + supabase client stub (#6)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,16 @@
+// Jest setup — runs after the test framework is installed.
+// 1) Stub @supabase/supabase-js so modules that initialize a client at import
+//    time (e.g. src/services/supabase.ts) don't throw "supabaseUrl is required"
+//    in CI where EXPO_PUBLIC_SUPABASE_URL is not set. Tests don't hit Supabase.
+// 2) Wire @testing-library/jest-native matchers into expect.
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({ data: { session: null }, error: null }),
+      exchangeCodeForSession: async () => ({ data: { session: null }, error: null }),
+      onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+    },
+  }),
+}));
+
+require('@testing-library/jest-native/extend-expect');

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "jest": {
     "preset": "jest-expo",
-    "setupFilesAfterFramework": ["@testing-library/jest-native/extend-expect"],
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
     ]


### PR DESCRIPTION
Closes #6

## Summary
- `package.json` 의 잘못된 jest 옵션 `setupFilesAfterFramework` 를 [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array) 로 정정
- `jest.setup.js` 신설해 `@supabase/supabase-js` 의 `createClient` 를 stub — CI 에는 `EXPO_PUBLIC_SUPABASE_URL` 이 없고 `EXPO_PUBLIC_*` 는 빌드 타임 inline 이라 setup 에서 `process.env` 주입해도 안 통함. createClient 자체를 mock 하는 쪽이 정공법

## Changes
- `package.json` — jest config 옵션 키 정정, setup 파일 경로 위임
- `jest.setup.js` (신규) — supabase stub + jest-native matchers

## Test plan
- [x] 로컬 `npm run test:coverage` 3 suites / 42 tests 통과
- [x] Validation Warning 미출력
- [ ] Actions `npm run test:coverage` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)